### PR TITLE
Fixed Pimiento Player Damage

### DIFF
--- a/Assets/Prefabs/Player Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player Prefabs/Player.prefab
@@ -408,6 +408,7 @@ MonoBehaviour:
   baseSpeed: 4
   speed: 0
   maxHealth: 10
+  baseDamageTakenMultiplier: 1
   damageTakenMultiplier: 1
   whipBaseDamageMultiplier: 1
   changeCooldownTime: 1
@@ -436,6 +437,8 @@ MonoBehaviour:
   midHealthThreshold: 0.6
   criticalThreshold: 0.2
   mixerEffect: {fileID: 2368722963072355761}
+  knockedBack: 0
+  progression: 0
 --- !u!114 &7699641391322968756
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player Scripts/Mixers/Pimiento.cs
+++ b/Assets/Scripts/Player Scripts/Mixers/Pimiento.cs
@@ -20,6 +20,6 @@ public class Pimiento : Mixer
 
     public override void RemoveMixer(Player player)
     {
-        player.damageTakenMultiplier /= pimientoValue;
+        player.damageTakenMultiplier = player.baseDamageTakenMultiplier;
     }
 }

--- a/Assets/Scripts/Player Scripts/Player.cs
+++ b/Assets/Scripts/Player Scripts/Player.cs
@@ -20,7 +20,8 @@ public class Player : MonoBehaviour, IDamageable
     [SerializeField] float maxHealth;
     private float health;
     [Tooltip("Multiplier for damage taken")]
-    public float damageTakenMultiplier;
+    public float baseDamageTakenMultiplier;
+    [HideInInspector] public float damageTakenMultiplier;
     [Tooltip("Percent damage dealt back from an enemy projectile")]
     public float whipBaseDamageMultiplier;
     [SerializeField] float changeCooldownTime;


### PR DESCRIPTION
- Before: Player would take 1 damage with pimiento and 0.5 without it when starting with pimiento
- After: Player always takes 1 damage without pimiento and 2 damage with it